### PR TITLE
Replace use of erlang.now with os.timestamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ current = ForecastIO.current(result)
 
 #Use ForecastIO Time API
 ```elixir
-{mega, secs, _ } = :erlang.now
+{mega, secs, _ } = :os.timestamp
 now = mega * 1000000 + secs
 ForecastIO.start()
 {:ok, result } = ForecastIO.forecast_time("28.6353","-106.0889", now)

--- a/test/forecast_io_time_test.exs
+++ b/test/forecast_io_time_test.exs
@@ -2,7 +2,7 @@ defmodule ForecastIOTimeTest do
   use ExUnit.Case
 
   test "it should accept a unix timestamp" do
-    {mega, secs, _ } = :erlang.now
+    {mega, secs, _ } = :os.timestamp
     now = mega * 1000000 + secs
     assert {:ok, result } = ForecastIO.forecast_time("28.6353","-106.0889",now)
     assert false = Enum.empty?(result)
@@ -10,7 +10,7 @@ defmodule ForecastIOTimeTest do
 
 
   test "it should accept a unix timestamp using float latitude and longitude" do
-    {mega, secs, _ } = :erlang.now
+    {mega, secs, _ } = :os.timestamp
     now = mega * 1000000 + secs
     assert {:ok, result } = ForecastIO.forecast_time(28.6353, -106.0889, now)
     assert false = Enum.empty?(result)


### PR DESCRIPTION
:erlang.now is deprecated in the next release of erlang (see
http://www.erlang.org/news/85) so it's probably best to switch to os.timestamp now.